### PR TITLE
Added version to fix CSR issue for OpenSSL 1.0.1

### DIFF
--- a/lib/letsencrypt/cli/acme_wrapper.rb
+++ b/lib/letsencrypt/cli/acme_wrapper.rb
@@ -80,6 +80,7 @@ class AcmeWrapper
         csr.add_attribute(attr)
       end
     end
+    csr.version = 2
     csr.public_key = certificate_private_key.public_key
     csr.sign(certificate_private_key, OpenSSL::Digest::SHA256.new)
     certificate = client.new_certificate(csr)


### PR DESCRIPTION
In older OpenSSL (CentOS bundled OpenSSL) the following happens: CSR generated using a pre-1.0.2 OpenSSL with a client that doesn't properly specify the CSR version.

This is inline with the certbot fix: https://github.com/certbot/certbot/commit/9f6ab814dd6f601029c48b7deec48982635e5415#diff-31d015f64b83c8ff85723c569cec870f